### PR TITLE
Add support for error functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,32 @@ use thiserror::Error;
 
 #[derive(Error, Debug, PartialEq, Eq)]
 pub enum MyError {
-   #[error("invalid value")]
-   InvalidValue,
+    #[error("invalid value")]
+    InvalidValue,
+}
+
+impl_enum_try_from!(
+    #[repr(u16)]
+    #[derive(PartialEq, Eq, Debug)]
+    enum MyEnum {
+        Foo = 0,
+        Bar = 1,
+        Baz = 2,
+    },
+    u16,
+    MyError,
+    MyError::InvalidValue
+);
+```
+
+```rust
+use enum_try_into::impl_enum_try_from;
+use thiserror::Error;
+
+#[derive(Error, Debug, PartialEq, Eq)]
+pub enum MyError {
+   #[error("invalid value: {0}")]
+   InvalidValue(u16),
 }
 
 impl_enum_try_from!(


### PR DESCRIPTION
I saw this crate and thought "that's perfect, but…" This crate presently supports returning `MyError::InvalidValue` but cannot return `MyError::InvalidValue(u16)`, which means it's not a direct replacement for some tedious code.

The macro gets `$err_ty:type` and `$err:expr`. If `$err` is a literal value of `$err_ty`, I want to use it as is. If `$err` is a closure, I want to pass it the `value` passed to `TryFrom`. But the macro can't  dispatch based on the type of `$err`! I was stuck.

A while later I realized that the macro doesn't _have to_ dispatch based on the type of `$err`. The macro can introduce a trait, implement both cases, and let the type system figure it out:

```rust
trait IntoError {
    fn into_error(self, value: $type) -> $err_ty;
}
impl IntoError for $err_ty {
    fn into_error(self, _: $type) -> $err_ty { self }
}
impl<F: FnOnce($type) -> $err_ty> IntoError for F {
    fn into_error(self, value: $type) -> $err_ty { self(value) }
}

$err.into_error(v)
```

As a bonus, because tuple structs are functions, this means a macro invocation where `$err` is `MyError::InvalidValue` does the right thing for both:

```rust
pub enum MyError {
   #[error("invalid value")]
   InvalidValue,
}

pub enum MyError {
   #[error("invalid value: {0}")]
   InvalidValue(u16),
}
```